### PR TITLE
FLOW-1793: Fixed missing authorization annotations causing authenticated whos to be null

### DIFF
--- a/timer-service/src/main/java/com/manywho/services/timer/service/controllers/WaitController.java
+++ b/timer-service/src/main/java/com/manywho/services/timer/service/controllers/WaitController.java
@@ -3,6 +3,7 @@ package com.manywho.services.timer.service.controllers;
 import com.manywho.sdk.entities.run.elements.config.ServiceRequest;
 import com.manywho.sdk.entities.run.elements.config.ServiceResponse;
 import com.manywho.sdk.enums.InvokeType;
+import com.manywho.sdk.services.annotations.AuthorizationRequired;
 import com.manywho.sdk.services.controllers.AbstractController;
 import com.manywho.services.timer.service.entities.WaitAbsoluteRequest;
 import com.manywho.services.timer.service.entities.WaitRelativeRequest;
@@ -23,6 +24,7 @@ public class WaitController extends AbstractController {
     @Inject
     private SchedulerService schedulerService;
 
+    @AuthorizationRequired
     @Path("/absolute")
     @POST
     public ServiceResponse absolute(ServiceRequest serviceRequest) throws Exception {
@@ -30,6 +32,7 @@ public class WaitController extends AbstractController {
         return scheduleWait(serviceRequest, waitAbsoluteRequest.getSchedule(), "absolute");
     }
 
+    @AuthorizationRequired
     @Path("/relative")
     @POST
     public ServiceResponse relative(ServiceRequest serviceRequest) throws Exception {

--- a/timer-service/src/main/java/com/manywho/services/timer/service/services/SchedulerService.java
+++ b/timer-service/src/main/java/com/manywho/services/timer/service/services/SchedulerService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.manywho.sdk.entities.security.AuthenticatedWho;
 import com.manywho.services.timer.common.jobs.WaitJob;
 import org.joda.time.DateTime;
-import org.joda.time.Seconds;
 import org.quartz.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,11 +21,6 @@ public class SchedulerService {
     private ObjectMapper objectMapper;
 
     public void scheduleWait(String type, DateTime schedule, AuthenticatedWho authenticatedWho, String stateId, String tenantId, String callbackUri, String token) throws Exception {
-        if (Seconds.secondsBetween(DateTime.now(), schedule).isLessThan(Seconds.seconds(120))) {
-            schedule = DateTime.now();
-            schedule = schedule.plusSeconds(120);
-        }
-
         String serializedAuthenticatedWho = objectMapper.writeValueAsString(authenticatedWho);
 
         JobDetail jobDetail = JobBuilder.newJob(WaitJob.class)


### PR DESCRIPTION
This fixes a long-standing issue in the service, where the current Authenticated Who object isn't sent back to the Engine correctly on callback after a scheduled job executes - it's always sent back as `null`, which isn't valid (but was inadvertently handled as valid by the Engine until fairly recently).

It was caused by a change in the SDK v1 a long time ago (maybe 4 years ago), where the `@AuthorizationRequired` annotation was made a requirement for the `AuthenticatedWho` object to be deserialized properly (it's long been fixed in SDK v2 which most of our services already use, FWIW).

Long term, this service should be updated to use SDK v2, but this change fixes the service not adhering to the External Service API contract correctly.

I also removed the now-useless 120 second minimum timer limit, as it will greatly hinder testing this in the API tests, and it was also removed in the old GitLab remote of this service, but never pushed to GitHub for some reason.